### PR TITLE
Modernize signed digit decomposition to avoid negative‑to‑uint casts

### DIFF
--- a/jaxite/jaxite_lib/decomposition.py
+++ b/jaxite/jaxite_lib/decomposition.py
@@ -196,12 +196,9 @@ def signed_decomposition(
     # and carry propagation
     carry_mask = unsigned_digit & base_over_2_threshold
 
-    # a tricky way to optionally shift by B. The result is re-cast as a uint32,
-    # but this is OK because future arithmetic operations as uint32 will wrap
-    # around and treat 2**32-1 properly as -1.
-    signed_digit = jnp.uint32(
-        jnp.int32(unsigned_digit) - jnp.int32(carry_mask << 1)
-    )
+    # Keep this arithmetic in uint32 so subtraction underflow wraps naturally.
+    # This avoids strict negative-to-uint casts (e.g. -1 -> uint32) in NumPy 2.x.
+    signed_digit = unsigned_digit - (carry_mask << 1)
 
     # convert the carry mask to a 0/1 bit to carry to the next digit
     carry = carry_mask >> (base_log - 1)

--- a/jaxite/jaxite_lib/decomposition_test.py
+++ b/jaxite/jaxite_lib/decomposition_test.py
@@ -165,6 +165,13 @@ class DecomposeTest(absltest.TestCase):
     )
     self.assertEqual(reconstructed, number)
 
+  def test_signed_decomposition_wraps_negative_digit(self):
+    # x=15 with base 16 yields a low signed digit of -1, represented as uint32.
+    decomp = decomposition.signed_decomposition(
+        15, base_log=4, num_levels=1, total_bit_length=4
+    )
+    np.testing.assert_array_equal(decomp, jnp.array([0xFFFFFFFF], dtype=jnp.uint32))
+
   def test_decompose_rlwe_ciphertext_vmap_compatibility(self):
     decomposition_params = decomposition.DecompositionParameters(
         log_base=4,


### PR DESCRIPTION
# Background: Why the original implementation looked this way

The original implementation of `signed_digit` used an explicit cast through `int32` before converting back to `uint32`:
``` python
signed_digit = jnp.uint32(
    jnp.int32(unsigned_digit) - jnp.int32(carry_mask << 1)
)
```
This pattern was intentional. In NumPy 1.x and earlier JAX/XLA behavior, casting a negative `int32` to `uint32` reliably produced a 2’s‑complement reinterpretation (e.g., `-1 → 0xFFFFFFFF`). This allowed the subtraction to occur in signed space while still yielding the correct wrap‑around unsigned result. At the time, this was a portable and predictable technique for implementing the signed‑digit arithmetic required by the decomposition logic.

# Problem: NumPy 2.x tightened casting semantics
NumPy 2.x introduced stricter rules around negative‑to‑unsigned integer casts, which now emit warnings or behave inconsistently across backends. Because the original implementation relied on producing negative intermediate values and then casting them to `uint32`, it became fragile under NumPy 2.x and could trigger warnings or undefined behavior.

# What was changed
The subtraction is now performed entirely in `uint32` space:
``` python
signed_digit = unsigned_digit - (carry_mask << 1)
```

# Why this change is correct and safer
- Cross‑compatible: Works identically under NumPy 1.x, NumPy 2.x, and all JAX/XLA backends.
- Avoids problematic casts: Eliminates negative‑to‑uint conversions that NumPy 2.x warns about.
- Preserves semantics: Produces the same 2’s‑complement wrap‑around behavior as the original code.
- Cleaner and faster: Removes unnecessary dtype conversions, improving compiler fusion and readability.
- More idiomatic: Aligns with JAX’s preference for keeping arithmetic within a single dtype.

Fixes #80 